### PR TITLE
remove autoload check in init

### DIFF
--- a/wp-gatsby.php
+++ b/wp-gatsby.php
@@ -42,10 +42,8 @@ final class WPGatsby {
 		if ( ! isset( self::$instance ) && ! ( self::$instance instanceof WPGatsby ) ) {
 			self::$instance = new WPGatsby();
 			self::$instance->setup_constants();
-			if ( WPGATSBY_AUTOLOAD ) {
-				self::$instance->includes();
-				self::$instance->init();
-			}
+			self::$instance->includes();
+			self::$instance->init();
 		}
 
 		return self::$instance;


### PR DESCRIPTION
as per the e-mail I sent you @TylerBarnes and @jasonbahl , here is my PR.

As I understand it, [the check for `WPGATSBY_AUTOLOAD` in `init()`](https://github.com/gatsbyjs/wp-gatsby/blob/master/wp-gatsby.php#L45) isn't needed because we need to [include `access-functions.php`](https://github.com/gatsbyjs/wp-gatsby/blob/master/wp-gatsby.php#L153) even when `WPGATSBY_AUTOLOAD` is set to `false`. The [check for `WPGATSBY_AUTOLOAD` inside `includes()`](https://github.com/gatsbyjs/wp-gatsby/blob/master/wp-gatsby.php#L147) is enough.

Currently, setting `WPGATSBY_AUTOLOAD` to `false` doesn't load this plugin correctly and `isWpGatsby` isn't added to the schema for example.