### PR TITLE
Fix modifyMeta() when user ID is passed

### DIFF
--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -205,6 +205,11 @@ class ActionMonitor {
 			return;
 		}
 
+		if ( ! get_post_type( $object_id ) && get_userdata( $object_id ) ) {
+			$this->updateUser( $object_id, 'UPDATE' );
+			return;
+		}
+
 		$this->savePost( $object_id );
 	}
 
@@ -619,7 +624,7 @@ class ActionMonitor {
 		}
 
 		$last_status_was_publish
-			= $this->post_object_before_update->post_status ?? null 
+			= $this->post_object_before_update->post_status ?? null
 				!== 'publish';
 
 		if (
@@ -636,7 +641,7 @@ class ActionMonitor {
 		if ( $post->post_type === 'action_monitor' ) {
 			return false;
 		}
-		
+
 		// if we've recorded this post being updated already
 		// no need to do it twice
 		if ( !$in_pre_save_post && in_array( $post->ID, $this->updated_post_ids ) ) {
@@ -659,7 +664,7 @@ class ActionMonitor {
 			]
 		);
 
-		
+
 		if ( $duplicate_actions->found_posts ) {
 			return false;
 		}
@@ -1002,9 +1007,9 @@ class ActionMonitor {
 
 	public function trigger_dispatch() {
 		$webhook_field = Settings::prefix_get_option( 'builds_api_webhook', 'wpgatsby_settings', false );
-		
+
 		if ( $webhook_field && $this->should_dispatch ) {
-			
+
 			$webhooks = explode( ',', $webhook_field );
 
 			foreach ( $webhooks as $webhook ) {


### PR DESCRIPTION
Fixes #17 

I'm not entirely confident on the user meta update flow, but this at least allows me to login without triggering a fatal error.