### PR TITLE
Add trigger dispatch filter

### DIFF
--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -1008,7 +1008,13 @@ class ActionMonitor {
 			$webhooks = explode( ',', $webhook_field );
 
 			foreach ( $webhooks as $webhook ) {
-				wp_safe_remote_post( $webhook );
+				$default_args = array(
+					'method' => 'POST',
+				);
+
+				$args = apply_filters( 'gatsby_trigger_dispatch_args', $default_args, $webhook );
+
+				wp_safe_remote_request( $webhook, $args );
 			}
 
 		}

--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -1008,13 +1008,9 @@ class ActionMonitor {
 			$webhooks = explode( ',', $webhook_field );
 
 			foreach ( $webhooks as $webhook ) {
-				$default_args = array(
-					'method' => 'POST',
-				);
+				$args = apply_filters( 'gatsby_trigger_dispatch_args', array(), $webhook );
 
-				$args = apply_filters( 'gatsby_trigger_dispatch_args', $default_args, $webhook );
-
-				wp_safe_remote_request( $webhook, $args );
+				wp_safe_remote_post( $webhook, $args );
 			}
 
 		}


### PR DESCRIPTION
This is a super simple solution for #22. 

Feel free to rename the filter to whatever makes the most sense. Not sure if you'd rather it be a `wp_gatsby` prefix.

I also thought about switching it to use `wp_safe_remote_request()`, to make it clearer that it could support sending a `GET` if that was required for some reason. But if someone forgot to merge the arguments when applying the filter or specify the method, then they would end up accidentally sending a `GET` request. 

The request method can still be overridden if it's passed in the arguments of `wp_safe_remote_post()`. 