### PR TITLE
Feat/add menu location delta syncing

### DIFF
--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -26,11 +26,6 @@ class ActionMonitor {
 	protected $updated_post_ids = [];
 
 	/**
-	 * An array of menu locations to menu id's before the menu is updated.
-	 */
-	protected $menu_locations_before_menu_update = [];
-
-	/**
 	 * Set up the Action monitor when the class is initialized
 	 */
 	function __construct() {

--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -625,9 +625,6 @@ class ActionMonitor {
 		// if no menu locations are assigned to this menu,
 		// bail early because it's a private menu
 		if ( !in_array( $menu_id, $menu_locations ) ) {
-			// send a delete event so that Gatsby no longer 
-			// has this menu if it had it before
-			$this->deleteMenu( $menu_id );
 			return $menu_id;
 		}
 

--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -179,9 +179,6 @@ class ActionMonitor {
 
 		add_action( 'delete_term', [ $this, 'deleteTerm' ], 10, 5 );
 
-		add_action( 'wp_update_term_parent', function() {
-		}, 10, 0);
-
 		$theme_slug = get_option( 'stylesheet' );
 
 		add_filter( "update_option_theme_mods_${theme_slug}", [ $this, 'deleteMenusWithNoLocation' ], 10, 2 );

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -94,6 +94,12 @@ class Settings {
 		return filter_var( $input, FILTER_VALIDATE_URL );
 	}
 
+	public static function get_setting( $key ) {
+		$wpgatsby_settings = get_option( 'wpgatsby_settings' );
+
+		return $wpgatsby_settings[ $key ] ?? null;
+	}
+
 	/**
 	 * Returns all the settings fields
 	 *

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -146,6 +146,13 @@ class Settings {
 					'sanitize_callback' => 'sanitize_text_field',
 					'default'           => self::get_default_secret(),
 				],
+				[
+					'name' => 'enable_gatsby_locations',
+					'label' => __( 'Enable Gatsby Menu Locations?', 'wpgatsby_settings' ),
+					'desc' => __( 'Yes', 'wpgatsby_settings' ),
+					'type' => 'checkbox',
+					'default' => 'on',
+				],
 			]
 		];
 

--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -111,13 +111,13 @@ class Settings {
 					'sanitize_callback' => function( $input ) {
 						return $this->sanitize_url_field( $input );
 					}
-        ],
-        [
-          'name' => 'enable_gatsby_preview',
-          'label' => __( 'Enable Gatsby Preview?', 'wpgatsby_settings' ),
-          'desc' => __( 'Yes', 'wpgatsby_settings' ),
-          'type' => 'checkbox'
-        ],
+				],
+				[
+					'name' => 'enable_gatsby_preview',
+					'label' => __( 'Enable Gatsby Preview?', 'wpgatsby_settings' ),
+					'desc' => __( 'Yes', 'wpgatsby_settings' ),
+					'type' => 'checkbox'
+				],
 				[
 					'name'              => 'preview_instance_url',
 					'label'             => __( 'Preview Instance', 'wpgatsby_settings' ),

--- a/src/ThemeSupport/ThemeSupport.php
+++ b/src/ThemeSupport/ThemeSupport.php
@@ -16,12 +16,12 @@ class ThemeSupport {
     function registerGatsbyMenuLocations() {
         register_nav_menus(
             [
-                'gatbsy-header-menu' => __( 'Header Menu [Gatsby]' ),
-                'gatbsy-header-menu-secondary' => __( 'Secondary Header Menu [Gatsby]' ),
-                'gatbsy-header-menu-tertiary' => __( 'Tertiary Header Menu [Gatsby]' ),
-                'gatbsy-footer-menu' => __( 'Footer Menu [Gatsby]' ),
-                'gatbsy-footer-menu-secondary' => __( 'Secondary Footer Menu [Gatsby]' ),
-                'gatbsy-footer-menu-tertiary' => __( 'Tertiary Footer Menu [Gatsby]' ),
+                'gatbsy-header-menu' => __( 'Header Menu [Gatsby]', 'WPGatsby' ),
+                'gatbsy-header-menu-secondary' => __( 'Secondary Header Menu [Gatsby]', 'WPGatsby' ),
+                'gatbsy-header-menu-tertiary' => __( 'Tertiary Header Menu [Gatsby]', 'WPGatsby' ),
+                'gatbsy-footer-menu' => __( 'Footer Menu [Gatsby]', 'WPGatsby' ),
+                'gatbsy-footer-menu-secondary' => __( 'Secondary Footer Menu [Gatsby]', 'WPGatsby' ),
+                'gatbsy-footer-menu-tertiary' => __( 'Tertiary Footer Menu [Gatsby]', 'WPGatsby' ),
             ]
         );
     }

--- a/src/ThemeSupport/ThemeSupport.php
+++ b/src/ThemeSupport/ThemeSupport.php
@@ -16,7 +16,7 @@ class ThemeSupport {
     }
     
     function registerGatsbyMenuLocations() {
-        $enable_gatsby_locations = Settings::get_setting('enable_gatsby_locations') === 'on';
+        $enable_gatsby_locations = 'on' === Settings::get_setting('enable_gatsby_locations');
 
         if ( !$enable_gatsby_locations ) {
             return;

--- a/src/ThemeSupport/ThemeSupport.php
+++ b/src/ThemeSupport/ThemeSupport.php
@@ -2,6 +2,8 @@
 
 namespace WPGatsby\ThemeSupport;
 
+use WPGatsby\Admin\Settings;
+
 /**
  * Modifies the schema
  */
@@ -14,15 +16,20 @@ class ThemeSupport {
     }
     
     function registerGatsbyMenuLocations() {
-        register_nav_menus(
+        $enable_gatsby_locations = Settings::get_setting('enable_gatsby_locations') === 'on';
+
+        if ( !$enable_gatsby_locations ) {
+            return;
+        }
+
+        $gatsby_locations = apply_filters(
+            'gatsby_locations',
             [
-                'gatbsy-header-menu' => __( 'Header Menu [Gatsby]', 'WPGatsby' ),
-                'gatbsy-header-menu-secondary' => __( 'Secondary Header Menu [Gatsby]', 'WPGatsby' ),
-                'gatbsy-header-menu-tertiary' => __( 'Tertiary Header Menu [Gatsby]', 'WPGatsby' ),
-                'gatbsy-footer-menu' => __( 'Footer Menu [Gatsby]', 'WPGatsby' ),
-                'gatbsy-footer-menu-secondary' => __( 'Secondary Footer Menu [Gatsby]', 'WPGatsby' ),
-                'gatbsy-footer-menu-tertiary' => __( 'Tertiary Footer Menu [Gatsby]', 'WPGatsby' ),
+                'gatbsy-header-menu' => __( 'Header Menu [Added by WPGatsby]', 'WPGatsby' ),
+                'gatbsy-footer-menu' => __( 'Footer Menu [Added by WPGatsby]', 'WPGatsby' ),
             ]
         );
+
+        register_nav_menus( $gatsby_locations );
     }
 }

--- a/src/ThemeSupport/ThemeSupport.php
+++ b/src/ThemeSupport/ThemeSupport.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace WPGatsby\ThemeSupport;
+
+/**
+ * Modifies the schema
+ */
+class ThemeSupport {
+	/**
+	 *
+	 */
+	function __construct() {
+        add_action( 'init', [ $this, 'registerGatsbyMenuLocations' ] );
+    }
+    
+    function registerGatsbyMenuLocations() {
+        register_nav_menus(
+            [
+                'gatbsy-header-menu' => __( 'Header Menu [Gatsby]' ),
+                'gatbsy-header-menu-secondary' => __( 'Secondary Header Menu [Gatsby]' ),
+                'gatbsy-header-menu-quaternary' => __( 'Quaternary Header Menu [Gatsby]' ),
+                'gatbsy-footer-menu' => __( 'Footer Menu [Gatsby]' ),
+                'gatbsy-footer-menu-secondary' => __( 'Secondary Footer Menu [Gatsby]' ),
+                'gatbsy-footer-menu-quaternary' => __( 'Quaternary Footer Menu [Gatsby]' ),
+            ]
+        );
+    }
+}

--- a/src/ThemeSupport/ThemeSupport.php
+++ b/src/ThemeSupport/ThemeSupport.php
@@ -18,10 +18,10 @@ class ThemeSupport {
             [
                 'gatbsy-header-menu' => __( 'Header Menu [Gatsby]' ),
                 'gatbsy-header-menu-secondary' => __( 'Secondary Header Menu [Gatsby]' ),
-                'gatbsy-header-menu-quaternary' => __( 'Quaternary Header Menu [Gatsby]' ),
+                'gatbsy-header-menu-tertiary' => __( 'Tertiary Header Menu [Gatsby]' ),
                 'gatbsy-footer-menu' => __( 'Footer Menu [Gatsby]' ),
                 'gatbsy-footer-menu-secondary' => __( 'Secondary Footer Menu [Gatsby]' ),
-                'gatbsy-footer-menu-quaternary' => __( 'Quaternary Footer Menu [Gatsby]' ),
+                'gatbsy-footer-menu-tertiary' => __( 'Tertiary Footer Menu [Gatsby]' ),
             ]
         );
     }

--- a/vendor/composer/autoload_classmap.php
+++ b/vendor/composer/autoload_classmap.php
@@ -57,4 +57,5 @@ return array(
     'WPGatsby\\Schema\\Schema' => $baseDir . '/src/Schema/Schema.php',
     'WPGatsby\\Schema\\SiteMeta' => $baseDir . '/src/Schema/SiteMeta.php',
     'WPGatsby\\Schema\\WPGatsbyWPGraphQLSchemaChanges' => $baseDir . '/src/Schema/WPGatsbyWPGraphQLSchemaChanges.php',
+    'WPGatsby\\ThemeSupport\\ThemeSupport' => $baseDir . '/src/ThemeSupport/ThemeSupport.php',
 );

--- a/vendor/composer/autoload_static.php
+++ b/vendor/composer/autoload_static.php
@@ -105,6 +105,7 @@ class ComposerStaticInitc0886b39d0133e2a7e0cedd66a0ecaf2
         'WPGatsby\\Schema\\Schema' => __DIR__ . '/../..' . '/src/Schema/Schema.php',
         'WPGatsby\\Schema\\SiteMeta' => __DIR__ . '/../..' . '/src/Schema/SiteMeta.php',
         'WPGatsby\\Schema\\WPGatsbyWPGraphQLSchemaChanges' => __DIR__ . '/../..' . '/src/Schema/WPGatsbyWPGraphQLSchemaChanges.php',
+        'WPGatsby\\ThemeSupport\\ThemeSupport' => __DIR__ . '/../..' . '/src/ThemeSupport/ThemeSupport.php',
     );
 
     public static function getInitializer(ClassLoader $loader)

--- a/wp-gatsby.php
+++ b/wp-gatsby.php
@@ -172,6 +172,11 @@ final class WPGatsby {
 		new \WPGatsby\Schema\Schema();
 
 		/**
+		 * Register Theme supports
+		 */
+		new \WPGatsby\ThemeSupport\ThemeSupport();
+
+		/**
 		 * Initialize Action Monitor
 		 */
 		new \WPGatsby\ActionMonitor\ActionMonitor();


### PR DESCRIPTION
Hey @jasonbahl  and @smthomas , 
Delta syncing for menus wasn't working when changing locations. I guess I didn't notice this before because locations originally weren't available when I added menu syncing support originally.

When the locations option is updated, the previous value is diffed with the new value to find any ids which no longer exist.
This works great because the only issue is when menus are removed from locations. When a menu location is added, the menu must be saved which causes Gatsby to re-fetch the saved menu.

The problem comes in when menu A sets a location which menu B previously had. Before this PR, Gatsby would have both menu A and B saved with the same location because only menu A was updated. Now when menu A is saved, the locations option updates, we diff it and see that menu B no longer has an option assigned so we send a delete event for menu B.

I've also added 6 default Gatsby menu locations as it was hella annoying switching themes to identify what the best way to do this was. Default locations will be useful for us and for our users so I added them.

<img width="499" alt="Screen Shot 2020-10-15 at 7 49 21 PM" src="https://user-images.githubusercontent.com/14190743/96207234-913c8f00-0f1f-11eb-8d94-a3748b5ae93a.png">
