### PR TITLE
#47 - force enable WPGraphQL Introspection

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -11,6 +11,50 @@ class Settings {
 
 		add_action( 'admin_init', [ $this, 'admin_init' ] );
 		add_action( 'admin_menu', [ $this, 'register_settings_page' ] );
+
+		// Filter the GraphQL Settings for introspection to force enable Introspection when WPGatsby is active
+		add_filter( 'graphql_setting_field_config', [ $this, 'filter_graphql_introspection_setting_field' ], 10, 3 );
+		add_filter( 'graphql_get_setting_section_field_value', [ $this, 'filter_graphql_introspection_setting_value' ], 10, 5 );
+	}
+
+	/**
+	 * Overrides the "public_introspection_enabled" setting field in the GraphQL Settings to be
+	 * checked and disabled so users can't uncheck it.
+	 *
+	 * @param array  $field_config The field config for the setting
+	 * @param string $field_name   The name of the field (unfilterable in the config)
+	 * @param string $section      The slug of the section the field is registered to
+	 *
+	 * @return mixed
+	 */
+	public function filter_graphql_introspection_setting_field( $field_config, $field_name, $section ) {
+		if ( 'graphql_general_settings' === $section && 'public_introspection_enabled' === $field_name ) {
+			$field_config['value']    = 'on';
+			$field_config['disabled'] = true;
+			$field_config['desc']     = $field_config['desc'] . ' (<strong>' . __( 'Force enabled by WPGatsby. Gatsby requires WPGraphQL introspection to communicate with WordPress.', 'wp-graphql' ) . '</strong>)';
+		}
+
+		return $field_config;
+	}
+
+	/**
+	 * Filters the value of the "public_introspection_enabled" setting to always be "on" when
+	 * WPGatsby is enabled
+	 *
+	 * @param mixed  $value          The value of the field
+	 * @param mixed  $default        The default value if there is no value set
+	 * @param string $field_name     The name of the option
+	 * @param array  $section_fields The setting values within the section
+	 * @param string $section_name   The name of the section the setting belongs to
+	 *
+	 * @return string
+	 */
+	public function filter_graphql_introspection_setting_value( $value, $default, $field_name, $section_fields, $section_name ) {
+		if ( 'graphql_general_settings' === $section_name && 'public_introspection_enabled' === $field_name ) {
+			return 'on';
+		}
+
+		return $value;
 	}
 
 	function admin_init() {
@@ -53,9 +97,9 @@ class Settings {
 		echo '<div class="wrap">';
 		echo '<div class="notice-info notice">
 			<p>'
-			. '<a target="_blank" href="'
-			. esc_url('https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/docs/tutorials/configuring-wp-gatsby.md')
-			. '">Learn how to configure WPGatsby here.</a></p>
+		     . '<a target="_blank" href="'
+		     . esc_url( 'https://github.com/gatsbyjs/gatsby-source-wordpress-experimental/blob/master/docs/tutorials/configuring-wp-gatsby.md' )
+		     . '">Learn how to configure WPGatsby here.</a></p>
 		</div>';
 		$this->settings_api->show_navigation();
 		$this->settings_api->show_forms();
@@ -119,10 +163,10 @@ class Settings {
 					}
 				],
 				[
-					'name' => 'enable_gatsby_preview',
+					'name'  => 'enable_gatsby_preview',
 					'label' => __( 'Enable Gatsby Preview?', 'wpgatsby_settings' ),
-					'desc' => __( 'Yes', 'wpgatsby_settings' ),
-					'type' => 'checkbox'
+					'desc'  => __( 'Yes', 'wpgatsby_settings' ),
+					'type'  => 'checkbox'
 				],
 				[
 					'name'              => 'preview_instance_url',
@@ -153,10 +197,10 @@ class Settings {
 					'default'           => self::get_default_secret(),
 				],
 				[
-					'name' => 'enable_gatsby_locations',
-					'label' => __( 'Enable Gatsby Menu Locations?', 'wpgatsby_settings' ),
-					'desc' => __( 'Yes', 'wpgatsby_settings' ),
-					'type' => 'checkbox',
+					'name'    => 'enable_gatsby_locations',
+					'label'   => __( 'Enable Gatsby Menu Locations?', 'wpgatsby_settings' ),
+					'desc'    => __( 'Yes', 'wpgatsby_settings' ),
+					'type'    => 'checkbox',
 					'default' => 'on',
 				],
 			]


### PR DESCRIPTION
This filters the settings field and the value returned by `get_graphql_setting()` for the `public_introspection_enabled` setting to always be enabled as long as WPGatsby is active. 

_**Note:** The filters this hooks into are introduced to WPGraphQL in the [v0.14.0](https://github.com/wp-graphql/wp-graphql/pull/1513) release. So if you're on WPGraphQL v0.13.* you will need to manually check the setting to enable introspection when using WPGraphQL with Gatsby Source WordPress Experimental._

## **Without WPGatsby Active:**

Introspection is _not_ enabled (but can be with the checkbox).

![Screen Shot 2020-10-23 at 11 35 38 PM](https://user-images.githubusercontent.com/1260765/97069467-e581e780-158d-11eb-9b37-0013e4a2d11f.png)

Here you can see GraphQL Playground cannot fetch the Schema but is provided an error saying that GraphQL Introspection is not allowed.

<img width="1198" alt="Screen Shot 2020-10-24 at 12 15 19 AM" src="https://user-images.githubusercontent.com/1260765/97069492-06e2d380-158e-11eb-9d41-f44b0c29e560.png">


## **With WPGatsby Active:**

Introspection is checked and the setting is disabled so users cannot change it, and a message is added to the description telling users that this option is force-enabled by WPGatsby. 

![Screen Shot 2020-10-23 at 11 34 46 PM](https://user-images.githubusercontent.com/1260765/97069470-eadf3200-158d-11eb-95a6-04041805edca.png)

And here you can see GraphQL Playground can fetch the Schema fine

<img width="1191" alt="Screen Shot 2020-10-24 at 12 14 59 AM" src="https://user-images.githubusercontent.com/1260765/97069496-0e09e180-158e-11eb-8a87-c37cf87b0816.png">

----

closes #47 
