### PR TITLE
Removed comma for compatibility with PHP 7.2 and earlier in the Previ…

### DIFF
--- a/src/Admin/Preview.php
+++ b/src/Admin/Preview.php
@@ -165,7 +165,7 @@ class Preview {
 								'Sorry, you are not allowed to update post %1$s',
 								'wp-gatsby'
 							),
-							$parent_id,
+							$parent_id
 						)
 					);
 				}
@@ -295,7 +295,7 @@ class Preview {
 								'Sorry, you are not allowed to access the Preview status of post %1$s',
 								'wp-gatsby'
 							),
-							$post_id,
+							$post_id
 						)
 					);
 				}
@@ -309,7 +309,7 @@ class Preview {
 				$found_preview_path_post_meta = get_post_meta(
 					$post_id,
 					'_wpgatsby_page_path',
-					true,
+					true
 				);
 
 				$revision = $this::getPreviewablePostObjectByPostId( $post_id );


### PR DESCRIPTION
Hi, 
I installed this plugin into my WordPress instance (version 5.5.3) but the parser of my PHP version throw an error about an unexpected token at the lines 169, 299, 312 into the file `wp-gatsby/src/Admin/Preview.php`

The unexpected token was a comma before a parenthesis `)` and considering that my PHP version is 7.2, this isn't allowed.
This error has broken my site but fortunately I fixed it. The PHP version suggested in the plugin's page here https://wordpress.org/plugins/wp-gatsby/#developers is 7.1 and higher, but based on my experience this isn't correct
  
I have created this small PR to remove the comma from the line to ensure compatibility with PHP 7.2 version and earlier :) 
