### PR TITLE
fix: disable polling in previews

### DIFF
--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -1082,13 +1082,23 @@ class ActionMonitor {
 	 * Triggers the dispatch to the remote endpoint(s)
 	 */
 	public function trigger_dispatch() {
-		$webhook_field = Settings::prefix_get_option( 'builds_api_webhook', 'wpgatsby_settings', false );
+		$build_webhook_field = Settings::prefix_get_option( 'builds_api_webhook', 'wpgatsby_settings', false );
+		$preview_webhook_field = Settings::prefix_get_option( 'preview_api_webhook', 'wpgatsby_settings', false );
 
-		if ( $webhook_field && $this->should_dispatch ) {
+		$we_should_call_webhooks = 
+			( $build_webhook_field || $preview_webhook_field ) &&
+			$this->should_dispatch;
 
-			$webhooks = explode( ',', $webhook_field );
+		if ( $we_should_call_webhooks ) {
+			$webhooks = array_merge(
+				explode( ',', $build_webhook_field ),
+				explode( ',', $preview_webhook_field)
+			);
 
-			foreach ( $webhooks as $webhook ) {
+			$truthy_webhooks = array_filter( $webhooks );
+			$unique_webhooks = array_unique( $truthy_webhooks ); 
+
+			foreach ( $unique_webhooks as $webhook ) {
 				$args = apply_filters( 'gatsby_trigger_dispatch_args', [], $webhook );
 
 				wp_safe_remote_post( $webhook, $args );

--- a/src/Admin/Preview.php
+++ b/src/Admin/Preview.php
@@ -501,6 +501,14 @@ class Preview {
 
 		$original_post = get_post( $post->post_parent );
 
+		$this_is_a_publish_not_a_preview = 
+			$original_post && $original_post->post_modified === $post->post_modified;
+
+		if ( $this_is_a_publish_not_a_preview ) {
+			// we will handle this in ActionMonitor.php, not here
+			return;
+		}
+
 		$parent_post_id = $original_post->ID ?? $post_ID;
 
 		$post_type_object = $original_post


### PR DESCRIPTION
Don't send previews for published posts, instead use the regular save post webhook logic to post to the preview instance.