### PR TITLE
fix: previews

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 0.7.2
+
+- Version 0.7.0 introduced a change which resulted in Previews for some WP instances being overwritten by published posts on each preview.
+
 ## 0.7.1
 
 - The last version added some internal taxonomies to the GraphQL schema unintentionally. This release removes them.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: Gatsby, GatsbyJS, JavaScript, JAMStack, Static Site generator, GraphQL, He
 Requires at least: 5.4
 Tested up to: 5.4
 Requires PHP: 7.1
-Stable tag: 0.7.1
+Stable tag: 0.7.2
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -428,7 +428,10 @@ class ActionMonitor {
 	}
 
 	function modifyMeta( $meta_id, $object_id, $meta_key ) {
-		if ( $meta_key === '_edit_lock' ) {
+		// if this is private meta, don't save any actions
+		// in WP the standard way to indicate that is to prefix
+		// the key with an underscore
+		if ( $meta_key[0] === '_' ) {
 			return;
 		}
 

--- a/wp-gatsby.php
+++ b/wp-gatsby.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WP Gatsby
  * Description: Optimize your WordPress site to be a source for Gatsby site(s).
- * Version: 0.7.1
+ * Version: 0.7.2
  * Author: GatsbyJS, Jason Bahl, Tyler Barnes
  * Author URI: https://gatsbyjs.org
  * Text Domain: wp-gatsby
@@ -98,7 +98,7 @@ final class WPGatsby {
 	private function setup_constants() {
 		// Plugin version.
 		if ( ! defined( 'WPGATSBY_VERSION' ) ) {
-			define( 'WPGATSBY_VERSION', '0.7.1' );
+			define( 'WPGATSBY_VERSION', '0.7.2' );
 		}
 
 		// Plugin Folder Path.


### PR DESCRIPTION
Version 0.7.0 introduced a change which resulted in Previews for some WP instances being overwritten by published posts on each preview.