### PR TITLE
Log, but do not dispatch webhooks for media item events

### DIFF
--- a/src/ActionMonitor/Monitors/MediaMonitor.php
+++ b/src/ActionMonitor/Monitors/MediaMonitor.php
@@ -50,7 +50,8 @@ class MediaMonitor extends  Monitor {
 				'relay_id'            => $global_relay_id,
 				'graphql_single_name' => 'mediaItem',
 				'graphql_plural_name' => 'mediaItems',
-			]
+			],
+			false // This skips scheduling the webhook.
 		);
 
 	}
@@ -83,7 +84,8 @@ class MediaMonitor extends  Monitor {
 				'relay_id'            => $global_relay_id,
 				'graphql_single_name' => 'mediaItem',
 				'graphql_plural_name' => 'mediaItems',
-			]
+			],
+			false // This skips scheduling the webhook.
 		);
 
 	}
@@ -116,7 +118,7 @@ class MediaMonitor extends  Monitor {
 				'relay_id'            => $global_relay_id,
 				'graphql_single_name' => 'mediaItem',
 				'graphql_plural_name' => 'mediaItems',
-			]
+			], false // This skips scheduling the webhook.
 		);
 
 	}

--- a/src/ActionMonitor/Monitors/Monitor.php
+++ b/src/ActionMonitor/Monitors/Monitor.php
@@ -175,8 +175,9 @@ abstract class Monitor {
 	 * $graphql_plural_name]
 	 *
 	 * @param array $args Array of arguments to configure the action to be inserted
+	 * @param bool $should_dispatch Whether the logged action should dispatch a webhook. Set to false to log the action but not schedule a dispatch.
 	 */
-	public function log_action( array $args ) {
+	public function log_action( array $args, $should_dispatch = true ) {
 
 		if (
 			! isset( $args['action_type'] ) ||
@@ -291,8 +292,12 @@ abstract class Monitor {
 
 		}
 
-		// we've saved at least 1 action, so we should update
-		$this->action_monitor->schedule_dispatch();
+		// If $should_dispatch is not set to false, schedule a dispatch. Actions being logged that
+		// set $should_dispatch to false will be logged, but not trigger a webhook immediately.
+		if ( false !== $should_dispatch ) {
+			// we've saved at least 1 action, so we should update
+			$this->action_monitor->schedule_dispatch();
+		}
 
 		// Delete old actions
 		$this->action_monitor->garbage_collect_actions();


### PR DESCRIPTION
This PR accomplishes the following:

- add an option to the `log_action` method to allow actions to be logged but **_not_** trigger a dispatch.

- Sets the media monitor actions to `$should_dispatch = false` so that the actions are logged, but do not trigger a dispatch. This allows for media items to be uploaded and edited and their actions get logged, but the webhook is not dispatched until another dispatched action (save post, for example) triggers a dispatch

----

closes #81 