### PR TITLE
Fix gatsby_pre_log_action_monitor_action docblock

### DIFF
--- a/src/ActionMonitor/Monitors/Monitor.php
+++ b/src/ActionMonitor/Monitors/Monitor.php
@@ -194,9 +194,9 @@ abstract class Monitor {
 		/**
 		 * Filter to allow skipping a logged action. If set to false, the action will not be logged.
 		 *
-		 * @param null Whether the action should be logged
-		 * @param array $args The args to log
-		 * @param Monitor $this Instance of the Monitor
+		 * @param null|bool $enable    Whether the action should be logged
+		 * @param array     $arguments The args to log
+		 * @param Monitor   $monitor   Instance of the Monitor
 		 */
 		$pre_log_action = apply_filters( 'gatsby_pre_log_action_monitor_action', null, $args, $this );
 


### PR DESCRIPTION
Where the confusion comes from: `@param` is for the parameter name (not the value) which are non-existent in this case.
