### PR TITLE
fix: Make sure the debug method exists before using it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Upcoming
+
+- Before using WPGraphQL::debug() we weren't making sure that the debug method exists on that class. This could throw errors for older versions of WPGraphQL - we now check that the method exists before using it.
+
 ## 1.0.6
 
 - Bump stable version tag

--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -52,7 +52,10 @@ class ActionMonitor {
 	public function __construct() {
 
 		// Determine if WPGraphQL is in debug mode
-		$this->wpgraphql_debug_mode = class_exists( 'WPGraphQL' ) ? \WPGraphQL::debug() : false;
+		$this->wpgraphql_debug_mode = 
+			class_exists( 'WPGraphQL' ) && method_exists( 'WPGraphQL', 'debug' ) 
+				? \WPGraphQL::debug()
+				: false;
 
 		// Initialize action monitors
 		add_action( 'wp_loaded', [ $this, 'init_action_monitors' ], 11 );


### PR DESCRIPTION
Before using WPGraphQL::debug() we weren't making sure that the debug method exists on that class. This could throw errors for older versions of WPGraphQL - we now check that the method exists before using it.