### PR TITLE
Improve release CI workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,13 +5,14 @@ on:
     - "*"
 jobs:
   tag:
-    name: New tag
+    name: Release
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@master
-    - name: WordPress Plugin Deploy
-      uses: 10up/action-wordpress-plugin-deploy@master
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Deploy to WordPress Plugin Directory
       env:
         SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
         SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
         SLUG: wp-gatsby
+      uses: 10up/action-wordpress-plugin-deploy@stable


### PR DESCRIPTION
- naming
- action branches
- etc.

https://github.com/10up/action-wordpress-plugin-deploy/branches