### PR TITLE
fix(preview): Prevent double slashes in page-data.json request so PINC routing works

### DIFF
--- a/src/Admin/Preview.php
+++ b/src/Admin/Preview.php
@@ -410,10 +410,11 @@ class Preview {
 							? "/index/"
 							: $found_preview_path_post_meta;
 		
+						$page_data_path_trimmed = trim( $page_data_path, "/" );
 
 						$modified_deployed_url =
 							$gatbsy_preview_frontend_url .
-							"page-data/$page_data_path/page-data.json";
+							"page-data/$page_data_path_trimmed/page-data.json";
 
 						// check if node page was deployed
 						$request  = wp_remote_get( $modified_deployed_url );


### PR DESCRIPTION
Double slashes in the page-data.json request url work in `gatsby develop` but since PINC serves static files a double slash will return a 404. For example `frontendurl.com/page-data/foo//bar/page-data.json` works in old preview but breaks in PINC. It needs to be `frontendurl.com/page-data/foo/bar/page-data.json` to succeed. This PR ensures there won't be double slashes in the url.