### PR TITLE
fix: Display error in browser when users preview on the wrong gatsby site

### DIFF
--- a/src/Admin/Preview.php
+++ b/src/Admin/Preview.php
@@ -388,7 +388,10 @@ class Preview {
 
 					if (
 						$node_modified_was_updated
-						&& 'NO_PAGE_CREATED_FOR_PREVIEWED_NODE' === $remote_status
+						&& (
+						'NO_PAGE_CREATED_FOR_PREVIEWED_NODE' === $remote_status
+						|| 'RECEIVED_PREVIEW_DATA_FROM_WRONG_URL' === $remote_status
+						)
 					) {
 						return [
 							'statusType'    => null,


### PR DESCRIPTION
This PR changes out preview status query so the preview loader can display an error if the Gatsby instance is configured to source data from a different WP instance.

<img width="850" alt="Screen Shot 2021-07-05 at 11 53 59 AM" src="https://user-images.githubusercontent.com/14190743/124512228-b5c9e700-dd8c-11eb-81b1-5354c0b0fc71.png">
<img width="1044" alt="Screen Shot 2021-07-05 at 12 18 19 PM" src="https://user-images.githubusercontent.com/14190743/124512230-b82c4100-dd8c-11eb-9c38-0ec67ccdf600.png">

related: https://github.com/gatsbyjs/gatsby/pull/32251