### PR TITLE
feat: Add Cloud loader support

### DIFF
--- a/src/Admin/Settings.php
+++ b/src/Admin/Settings.php
@@ -213,8 +213,8 @@ class Settings {
 			'wpgatsby_settings' => [
 				[
 					'name'              => 'builds_api_webhook',
-					'label'             => __( 'Builds Webhook', 'wpgatsby_settings' ),
-					'desc'              => __( 'Enter your Gatsby Builds Webhook URL. Must begin with http:// or https://. Use a comma-separated list to configure multiple webhooks.', 'wpgatsby_settings' ),
+					'label'             => __( 'Builds Webhook URL', 'wpgatsby_settings' ),
+					'desc'              => __( 'Use a comma-separated list to configure multiple webhooks.', 'wpgatsby_settings' ),
 					'placeholder'       => __( 'https://', 'wpgatsby_settings' ),
 					'type'              => 'text',
 					'sanitize_callback' => function ( $input ) {
@@ -224,13 +224,27 @@ class Settings {
 				[
 					'name'  => 'enable_gatsby_preview',
 					'label' => __( 'Enable Gatsby Preview?', 'wpgatsby_settings' ),
-					'desc'  => __( 'Yes', 'wpgatsby_settings' ),
+					'desc'  => __( 'Yes, allow Gatsby to take over WordPress previews.', 'wpgatsby_settings' ),
 					'type'  => 'checkbox',
 				],
 				[
+					'name'  => 'use_preview_loader',
+					'label' => __( 'Use Gatsby Preview Loader?', 'wpgatsby_settings' ),
+					'desc'  => __( 'Yes, I want to use Gatsby Cloud to redirect admins to the right preview page. (recommended)', 'wpgatsby_settings' ),
+					'type'  => 'checkbox',
+				],
+				[
+					'name'              => 'preview_loader_url',
+					'label'             => __( 'Preview Loader URL', 'wpgatsby_settings' ),
+					'placeholder'       => __( 'https://', 'wpgatsby_settings' ),
+					'type'              => 'text',
+					'sanitize_callback' => function ( $input ) {
+						return $this->sanitize_url_field( $input );
+					},
+				],
+				[
 					'name'              => 'preview_instance_url',
-					'label'             => __( 'Preview Instance', 'wpgatsby_settings' ),
-					'desc'              => __( 'Enter your Gatsby Preview instance URL. Must begin with http:// or https://.', 'wpgatsby_settings' ),
+					'label'             => __( 'Preview Frontend URL', 'wpgatsby_settings' ),
 					'placeholder'       => __( 'https://', 'wpgatsby_settings' ),
 					'type'              => 'text',
 					'sanitize_callback' => function ( $input ) {
@@ -239,8 +253,8 @@ class Settings {
 				],
 				[
 					'name'              => 'preview_api_webhook',
-					'label'             => __( 'Preview Webhook', 'wpgatsby_settings' ),
-					'desc'              => __( 'Enter your Gatsby Preview Webhook URL. Must begin with http:// or https://. Use a comma-separated list to configure multiple webhooks.', 'wpgatsby_settings' ),
+					'label'             => __( 'Preview Webhook URL', 'wpgatsby_settings' ),
+					'desc'              => __( 'Use a comma-separated list to configure multiple webhooks.', 'wpgatsby_settings' ),
 					'placeholder'       => __( 'https://', 'wpgatsby_settings' ),
 					'type'              => 'text',
 					'sanitize_callback' => function ( $input ) {

--- a/src/Admin/includes/preview-template.php
+++ b/src/Admin/includes/preview-template.php
@@ -3,6 +3,7 @@
 use WPGatsby\Admin\Preview;
 
 $preview_url = Preview::get_gatsby_preview_instance_url();
+$use_preview_loader = self::get_setting( 'use_preview_loader' );
 ?>
 
 <html lang="en">
@@ -18,6 +19,20 @@ $preview_url = Preview::get_gatsby_preview_instance_url();
 	</style>
 
 	<script>
+		<?php
+			if ( $use_preview_loader ) {
+				// Gutenberg seems to be using the preview_post_link filter so we may never reach this code path now. In the past Gutenberg did not respect this filter so there was no way to change the preview link.
+				// Leaving this here incase a user somehow makes it to the preview template when they should be at the loader.
+				// Redirecting via JS because the page headers have already been set by the time we get into this template so PHP wont redirect.
+				global $post;
+
+				$preview_loader_url = Preview::get_preview_loader_url_for_post(
+					$post
+				);
+
+				echo 'window.location.replace("'. $preview_loader_url .'")';
+			}
+		?>
 		<?php Preview::print_initial_preview_template_state_js(); ?>        
 		<?php Preview::printFileContents( 'assets/dist/preview-client.js' ); ?>
 	</script>


### PR DESCRIPTION
This adds support for the upcoming Gatsby Cloud preview loader which will replace the WPGatsby preview loader.

This is a draft because it shouldn't be merged/released until this feature is released.