### PR TITLE
Add REST_REQUEST check.

### DIFF
--- a/src/ActionMonitor/Monitors/PostMonitor.php
+++ b/src/ActionMonitor/Monitors/PostMonitor.php
@@ -58,6 +58,10 @@ class PostMonitor extends Monitor {
 			return;
 		}
 
+        if(defined("REST_REQUEST") && REST_REQUEST) {
+            return;
+        }
+
 		// If the object is not a valid post, ignore it
 		if ( ! is_a( $post, 'WP_Post' ) ) {
 			return;


### PR DESCRIPTION
We were having issues with webhook firing multiple times. Added a check for the REST_REQUEST constant defined in Wordpres and the webhook is now firing a single time on post update. 