### PR TITLE
fix: Set publicly_queryable for WPGraphQL 1.6.7+

### DIFF
--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -147,7 +147,7 @@ class ActionMonitor {
 				'labels'                => $post_type_labels,
 				'description'           => 'Used to keep a log of actions in WordPress for cache invalidation in gatsby-source-wordpress.',
 				'public'                => false,
-				'publicly_queryable'    => false,
+				'publicly_queryable'    => true,
 				'show_ui'               => $this->wpgraphql_debug_mode,
 				'delete_with_user'      => false,
 				'show_in_rest'          => false,


### PR DESCRIPTION
WPGraphQL made a breaking change in a minor release `v1.6.7` which caused delta updates to stop working. This PR fixes that.

Related to https://github.com/wp-graphql/wp-graphql/issues/2142 and https://github.com/gatsbyjs/gatsby/discussions/33856

Closes https://github.com/gatsbyjs/wp-gatsby/issues/200