### PR TITLE
fix: pass ActionMonitor instance to `gatsby_action_monitors` filter

### DIFF
--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -364,8 +364,9 @@ class ActionMonitor {
 		 * be necessary. Override with caution.
 		 *
 		 * @param array $action_monitors
+		 * @param \WPGatsby\ActionMonitor\ActionMonitor $monitor The class instance, used to initialize the monitor.
 		 */
-		$this->action_monitors = apply_filters( 'gatsby_action_monitors', $action_monitors );
+		$this->action_monitors = apply_filters( 'gatsby_action_monitors', $action_monitors, $this );
 
 		do_action( 'gatsby_init_action_monitors', $this->action_monitors );
 


### PR DESCRIPTION
Per the conversation in #174 , the following PR adds the `\WPGatsby\ActionMonitor\ActionMonitor` instance to the `gatsby_action_monitors` hook, in order to reintroduce the ability to register custom action monitors.

The PR adopts @alevgal 's [solution](https://github.com/gatsbyjs/wp-gatsby/issues/174#issuecomment-853851266). This method was chosen as it is an isolated (non-breaking) change that has no other effects on the existing codebase.

The only "downside" of this approach is that action monitors cannot be extended using the functional method referenced in the docs pre-commit. However, that isn't currently possible anyway (and would likely require a breaking change to imlement).

## How to use:

```php
/**
 * Class - MyCustomActionMonitor
 */
class MyCustomActionMonitor extends \WPGatsby\ActionMonitor\Monitors\Monitor {

	/**
	 * Initialize the custom tracker.
	 */
	public function init() {
		// Hook into the custom action you want to log.
		add_action( 'my_custom_action', [ $this, 'custom_action_callback' ] );
	}

	/**
	 * Callback for custom action.
	 */
	public function custom_action_callback( $your_custom_object ) {

		/**
		 * Log an action to Action Monitor. 
		 * 
		 * This will create an entry in the `action_monitor` post type
		 * and will notify Gatsby Source WordPress about the activity.
		 */
		$this->monitor->log_action( [
			'action_type' => 'CREATE',
			'title' => $your_custom_object->title,
			'graphql_single_name' => 'MyCustomType',
			'graphql_plural_name' => 'MyCustomTypes',
			'status' => 'publish',
			'relay_id' => base64_encode( 'MyCustomType:' . $your_custom_object->ID ),
			'node_id' => $your_custom_object->ID,
		] );
	}
}

add_filter( 'gatsby_action_monitors', function( array $monitors, \WPGatsby\ActionMonitor\ActionMonitor $action_monitor) {
	$monitors['MyCustomActionMonitor'] = new MyCustomActionMonitor( $action_monitor );

	return $monitors;
}, 10, 2 );
```
