### PR TITLE
fix: use gmdate and post_modified_gmt to prevent using local timezone

### DIFF
--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -613,8 +613,11 @@ class ActionMonitor {
 				if ( $sinceTimestamp ) {
 					$args['date_query'] = [
 						[
-							'after'  => date( 'c', $sinceTimestamp / 1000 ),
-							'column' => 'post_modified',
+							'after'  =>  gmdate(
+								'Y-m-d H:i:s',
+								$sinceTimestamp / 1000
+							),
+							'column' => 'post_modified_gmt',
 						],
 					];
 				}


### PR DESCRIPTION
This makes the action monitor sinceTimeStamp gql arg work properly when the local timezone is not UTC+0.