### PR TITLE
ACF Options Page Monitoring

### DIFF
--- a/src/ActionMonitor/Monitors/AcfMonitor.php
+++ b/src/ActionMonitor/Monitors/AcfMonitor.php
@@ -37,7 +37,13 @@ class AcfMonitor extends Monitor {
      * Handles content updates of ACF option pages.
      */
     public function after_acf_save_post() {
-        $option_pages_slugs = array_keys( acf_get_options_pages() );
+        $option_pages = acf_get_options_pages();
+
+        if ( ! is_array( $option_pages ) ) {
+            return;
+        }
+
+        $option_pages_slugs = array_keys( $option_pages );
 
         /**
          * Filters the $option_pages_slugs array.

--- a/src/ActionMonitor/Monitors/AcfMonitor.php
+++ b/src/ActionMonitor/Monitors/AcfMonitor.php
@@ -37,7 +37,7 @@ class AcfMonitor extends Monitor {
      * Handles content updates of ACF option pages.
      */
     public function after_acf_save_post() {
-        $option_pages_slugs = array_keys(acf_get_options_pages());
+        $option_pages_slugs = array_keys( acf_get_options_pages() );
 
         /**
          * Filters the $option_pages_slugs array.
@@ -46,11 +46,14 @@ class AcfMonitor extends Monitor {
          *
          * @param	array $option_pages_slugs Array with slugs of all registered ACF option pages.
          */
-        $option_pages_slugs = apply_filters('gatsby_action_monitor_tracked_acf_options_pages', $option_pages_slugs);
+        $option_pages_slugs = apply_filters(
+			'gatsby_action_monitor_tracked_acf_options_pages',
+			$option_pages_slugs
+		);
 
         $screen = get_current_screen();
 
-        if(!empty($option_pages_slugs) && is_array($option_pages_slugs) && Utils::str_in_substr_array($screen->id, $option_pages_slugs)) {
+        if( ! empty( $option_pages_slugs ) && is_array( $option_pages_slugs ) && Utils::str_in_substr_array( $screen->id, $option_pages_slugs ) ) {
             $this->trigger_non_node_root_field_update();
         }
     }

--- a/src/ActionMonitor/Monitors/AcfMonitor.php
+++ b/src/ActionMonitor/Monitors/AcfMonitor.php
@@ -2,6 +2,8 @@
 
 namespace WPGatsby\ActionMonitor\Monitors;
 
+use WPGatsby\Utils\Utils;
+
 class AcfMonitor extends Monitor {
 
 	public function init() {
@@ -28,8 +30,28 @@ class AcfMonitor extends Monitor {
 			}
 		);
 
-		// @todo: Add support for tracking ACF Options Fields.
-
+        add_action('acf/save_post', [$this, 'after_acf_save_post'], 20);
 	}
 
+    /**
+     * Handles content updates of ACF option pages.
+     */
+    public function after_acf_save_post() {
+        $option_pages_slugs = array_keys(acf_get_options_pages());
+
+        /**
+         * Filters the $option_pages_slugs array.
+         *
+         * @since 2.1.2
+         *
+         * @param	array $option_pages_slugs Array with slugs of all registered ACF option pages.
+         */
+        $option_pages_slugs = apply_filters('gatsby_action_monitor_tracked_acf_options_pages', $option_pages_slugs);
+
+        $screen = get_current_screen();
+
+        if(!empty($option_pages_slugs) && is_array($option_pages_slugs) && Utils::str_in_substr_array($screen->id, $option_pages_slugs)) {
+            $this->trigger_non_node_root_field_update();
+        }
+    }
 }

--- a/src/ActionMonitor/Monitors/AcfMonitor.php
+++ b/src/ActionMonitor/Monitors/AcfMonitor.php
@@ -53,7 +53,11 @@ class AcfMonitor extends Monitor {
 
         $screen = get_current_screen();
 
-        if( ! empty( $option_pages_slugs ) && is_array( $option_pages_slugs ) && Utils::str_in_substr_array( $screen->id, $option_pages_slugs ) ) {
+        if(
+			! empty( $option_pages_slugs ) 
+			&& is_array( $option_pages_slugs )
+			&& Utils::str_in_substr_array( $screen->id, $option_pages_slugs )
+		) {
             $this->trigger_non_node_root_field_update();
         }
     }

--- a/src/Utils/Utils.php
+++ b/src/Utils/Utils.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace WPGatsby\Utils;
+
+class Utils {
+
+    /**
+     * Checks if any of the strings in $substr_array is a substring in the $haystack.
+     *
+     * @since 2.1.2
+     *
+     * @param string $haystack
+     * @param array $substr_array
+     * @param int $offset
+     *
+     * @return bool
+     */
+    public static function str_in_substr_array(string $haystack, array $substr_array, int $offset = 0): bool {
+        foreach ( $substr_array as $substr ) {
+            if ($substr && strpos($haystack, $substr, $offset) !== false ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
Possible related issues: #114, #174, #183, #181

This PR approaches the problem of ACF Option pages not triggering content updates in Gatsby if the options are "saved/updated".

As per suggestion of @TylerBarnes, `trigger_non_node_root_field_update` is used to update the option fields. By default this implementation would apply monitoring for all ACF registered option pages, but makes sure that it is only applied on those and not on normal post types to prevent triggering multiple content updates.

With the filter in place one can whitelist specific pages for monitoring or turn of monitoring by passing an empty array (or false).

```
add_filter('gatsby_action_monitor_tracked_acf_options_pages', function () {
    return ['my-custom-option-page'];
});
```

- [x] Adds ACF option page monitoring
- [x] Introduces Utils Class for helper functions
- [x] Introduces  `gatsby_action_monitor_tracked_acf_options_pages` filter
- [ ] Documentation

