### PR TITLE
feat: Add eager redirects support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Change Log
 
+## Upcoming
+
+Added support for Gatsby Cloud Preview's new feature "eager redirects" which reduces the amount of time spent watching the preview loading screen by redirecting to the preview frontend as soon as possible and then letting the user wait for the preview to finish building there.
+
 ## 2.1.1
 
-Changing away from the default UTC+0 timezone in WP could cause problems with local development and syncing changed data from WP. This releas fixes that via PR #204.
+Changing away from the default UTC+0 timezone in WP could cause problems with local development and syncing changed data from WP. This release fixes that via PR #204.
 
 ## 2.1.0
 

--- a/src/Admin/Preview.php
+++ b/src/Admin/Preview.php
@@ -20,9 +20,10 @@ class Preview {
 		// get the Gatsby Cloud loader url w/ site id
 		$gatsby_content_sync_url = Settings::get_setting( 'gatsby_content_sync_url' );
 					
-		// create the dynamic path the loader will need
+		// Create the dynamic path Content Sync will need
 		$manifest_id = self::get_preview_manifest_id_for_post( $post );
-		$path = "/gatsby-source-wordpress/$manifest_id";
+		$content_id = $post->ID;
+		$path = "/gatsby-source-wordpress/$manifest_id/$content_id";
 
 		$url = preg_replace(
 			// remove any double forward slashes from the path


### PR DESCRIPTION
This adds eager redirects support for Content Sync. 

This shouldn't be merged until Gatsby Cloud supports eager redirects.