### PR TITLE
fix: return early if acf options page fn isn't defined

### DIFF
--- a/src/ActionMonitor/Monitors/AcfMonitor.php
+++ b/src/ActionMonitor/Monitors/AcfMonitor.php
@@ -37,10 +37,14 @@ class AcfMonitor extends Monitor {
      * Handles content updates of ACF option pages.
      */
     public function after_acf_save_post() {
+		if ( ! function_exists( 'acf_get_options_pages' ) ) {
+			return;
+		}
+
         $option_pages = acf_get_options_pages();
 
         if ( ! is_array( $option_pages ) ) {
-            return;
+			return;
         }
 
         $option_pages_slugs = array_keys( $option_pages );


### PR DESCRIPTION
fixes #214 