### PR TITLE
fix: preview for all roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Upcoming
+
+Previously Author and Contributor roles couldn't properly use Gatsby Cloud Preview. This release introduces new custom role capabilities which allow all authenticated users that can use WP preview to use Gatsby Preview.
+
 ## 2.3.1
 
 Fixes bug in last version where not having the right ACF version installed would throw an error about `Call to undefined function "acf_get_options_pages"`

--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -80,7 +80,7 @@ class ActionMonitor {
 		add_action( 'shutdown', [ $this, 'trigger_dispatch' ] );
 
 		// allow any role to use Gatsby Preview
-		add_action( 'admin_init', [$this, 'action_monitor_add_role_caps'], 999 );
+		add_action( 'admin_init', [ $this, 'action_monitor_add_role_caps' ], 999 );
 	}
 
 	/**

--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -79,6 +79,34 @@ class ActionMonitor {
 		// Trigger webhook dispatch
 		add_action( 'shutdown', [ $this, 'trigger_dispatch' ] );
 
+		// allow any role to use Gatsby Preview
+		add_action( 'admin_init', [$this, 'action_monitor_add_role_caps'], 999 );
+	}
+
+	/**
+	 * For Action Monitor, all of these roles need to be able to view and edit private action monitor posts so that Preview works for all roles.
+	 */
+	public function action_monitor_add_role_caps() {
+		$doing_graphql_request
+					= defined( 'GRAPHQL_REQUEST' ) && true === GRAPHQL_REQUEST;
+
+		if ( $doing_graphql_request ) {
+			// we only need to add roles one time. checking capabilities repeatedly isn't needed, just when the user is in the admin area is fine.
+			return;
+		}
+
+		$roles = array( 'editor', 'administrator', 'contributor', 'author' );
+
+		foreach( $roles as $the_role ) {
+			$role = get_role($the_role);
+			if ( ! $role->has_cap( 'read_private_action_monitor_posts' ) ) {
+				$role->add_cap( 'read_private_action_monitor_posts' );
+			}
+			
+			if ( ! $role->has_cap( 'edit_others_action_monitor_posts' ) ) {
+				$role->add_cap( 'edit_others_action_monitor_posts' );
+			}
+		}
 	}
 
 	/**
@@ -157,8 +185,20 @@ class ActionMonitor {
 				'show_in_menu'          => $this->wpgraphql_debug_mode,
 				'show_in_nav_menus'     => false,
 				'exclude_from_search'   => true,
-				'capability_type'       => 'post',
-				'map_meta_cap'          => true,
+				'capabilities'          => [
+					// these custom capabilities allow any role to use Preview
+					'read_private_posts' => 'read_private_action_monitor_posts',
+					'edit_others_posts'  => 'edit_others_action_monitor_posts', 
+					// these are regular role capabilities for a CPT
+					'create_post'        => 'create_post', 
+					'edit_post'          => 'edit_post', 
+					'read_post'          => 'read_post', 
+					'delete_post'        => 'delete_post', 
+					'edit_posts'         => 'edit_posts', 
+					'publish_posts'      => 'publish_posts',       
+					'create_posts'       => 'create_posts'
+				],
+				'map_meta_cap'          => false,
 				'hierarchical'          => false,
 				'rewrite'               => [
 					'slug'       => 'action_monitor',

--- a/src/ActionMonitor/ActionMonitor.php
+++ b/src/ActionMonitor/ActionMonitor.php
@@ -95,10 +95,19 @@ class ActionMonitor {
 			return;
 		}
 
-		$roles = array( 'editor', 'administrator', 'contributor', 'author' );
+		$roles = apply_filters(
+			'gatsby_private_action_monitor_roles',
+			[
+				'editor',
+				'administrator',
+				'contributor',
+				'author'
+			]
+		);
 
 		foreach( $roles as $the_role ) {
 			$role = get_role($the_role);
+
 			if ( ! $role->has_cap( 'read_private_action_monitor_posts' ) ) {
 				$role->add_cap( 'read_private_action_monitor_posts' );
 			}

--- a/src/ActionMonitor/Monitors/SettingsMonitor.php
+++ b/src/ActionMonitor/Monitors/SettingsMonitor.php
@@ -79,7 +79,6 @@ class SettingsMonitor extends Monitor {
 				'timezone_string',
 				'default_post_format',
 				'site_icon',
-				'wp_user_roles',
 				'current_theme',
 			]
 		);


### PR DESCRIPTION
Previously Author and Contributor roles couldn't properly use Gatsby Cloud Preview (it just wouldn't work). This PR introduces new custom role capabilities which allow all authenticated users that can use WP preview to use Gatsby Preview.