### PR TITLE
Fix issue with saving Product Categories

### DIFF
--- a/src/ActionMonitor/Monitors/AcfMonitor.php
+++ b/src/ActionMonitor/Monitors/AcfMonitor.php
@@ -63,12 +63,16 @@ class AcfMonitor extends Monitor {
 
         $screen = get_current_screen();
 
-        if(
-			! empty( $option_pages_slugs ) 
-			&& is_array( $option_pages_slugs )
-			&& Utils::str_in_substr_array( $screen->id, $option_pages_slugs )
-		) {
-            $this->trigger_non_node_root_field_update();
-        }
+		if (!empty($screen->id)) {
+			if (is_string($screen->id)) {
+				if(
+					! empty( $option_pages_slugs )
+					&& is_array( $option_pages_slugs )
+					&& Utils::str_in_substr_array( $screen->id, $option_pages_slugs )
+				) {
+					$this->trigger_non_node_root_field_update();
+				}
+			}
+		}
     }
 }


### PR DESCRIPTION
When saving product categories we get 500 error:
`PHP Fatal error:  Uncaught TypeError: Argument 1 passed to WPGatsby\Utils\Utils::str_in_substr_array() must be of the type string, null given.`

To fix this issue we have added check if $screen->id exist and if it's  string.

There should always exist some check or error handler when working with this type of checks.